### PR TITLE
FIX:password_reset_update

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -14,7 +14,7 @@ class PasswordResetsController < ApplicationController
     return not_authenticated if @user.blank?
   end
 
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  # HACK: Refactor this method to reduce ABC size and method length.
   def update
     @token = params[:id]
     @user = User.load_from_reset_password_token(params[:id])
@@ -23,12 +23,16 @@ class PasswordResetsController < ApplicationController
     @user.password = params[:user][:password]
     @user.password_confirmation = params[:user][:password_confirmation]
 
-    if @user.save
-      redirect_to login_path, notice: t('.success')
+    if @user.password.present? && @user.password == @user.password_confirmation
+      if @user.change_password(params[:user][:password])
+        redirect_to login_path, notice: t('.success')
+      else
+        flash.now[:alert] = @user.errors.full_messages
+        render :edit
+      end
     else
-      flash.now[:alert] = @user.errors.full_messages
+      flash.now[:alert] = t('.unmatch')
       render :edit
     end
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -7,7 +7,7 @@ class ProfilesController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to profile_path(current_user), success: t('.success')
+      redirect_to profile_path(current_user), notice: t('.success')
     else
       flash.now[:alert] = @user.errors.full_messages
       render :edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,10 +10,9 @@ class User < ApplicationRecord
   validates :email, { presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX } }
   validates :password, presence: true, length: { minimum: 5 },
                        if: lambda {
-                         new_record? ||
-                           changes[:crypted_password] ||
-                           reset_password_token.present?
-                       }
+                             new_record? ||
+                               changes[:crypted_password]
+                           }
   validates :password, confirmation: true,
                        if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true,

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -81,6 +81,7 @@ ja:
       submit: '作成する'
     update:
       success: 'パスワードを変更しました'
+      unmatch: 'パスワードが一致しません'
   gift_suggestions:
     index:
       title: 'プレゼント相談履歴一覧'
@@ -176,6 +177,8 @@ ja:
       title: 'プロフィール編集'
       delimit_hobby: '、や・で区切って下さい'
       submit: '編集する'
+    update:
+      success: 'プロフィールを編集しました'
   instructions:
     title: "使い方の説明"
     steps:


### PR DESCRIPTION
## 概要

password_resetにおいて現状のコードだと一度でもパスワードリセットを行なったユーザーにはtokenが付与されるためその後プロフィール編集を行う際にパスワードを要求されてしまう不具合があったため修正しています

## 確認方法

1. 新規ユーザーを作成しプロフィール編集できることを確認して下さい
2. パスワードリセットを行なって下さい
3. リセット後再度プロフィールが編集できることを確認して下さい

## チェックリスト

- [x] Lint のチェックをパスした

## コメント

password_reset_controllerのupdateにHACK残していますがMVPリリース後に修正いたします