### PR TITLE
FIX:profile_id_delete

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -7,7 +7,7 @@ class ProfilesController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to profile_path(current_user), notice: t('.success')
+      redirect_to profile_path, notice: t('.success')
     else
       flash.now[:alert] = @user.errors.full_messages
       render :edit

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, t('.title')) %>
 <div class="container max-w-md mx-auto ">
   <h1 class="mb-5 text-4xl text-center"><%= t('.title') %></h1>
-  <%= form_with model: @user, url: profile_path(current_user), local: true, data: { turbo: false }, class: "w-96 mx-auto p-6 bg-white rounded-lg shadow-md" do |f| %>
+  <%= form_with model: @user, url: profile_path, local: true, data: { turbo: false }, class: "w-96 mx-auto p-6 bg-white rounded-lg shadow-md" do |f| %>
     <div class="mb-4">
       <%= f.label :name, class: "block text-gray-700 text-sm font-bold mb-2" do %>
         <%= f.object.class.human_attribute_name(:name) %> <span class="text-red-500">*</span>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -38,6 +38,6 @@
     </div>
   </div>
   <div class="mt-8 text-center sm:px-6">
-    <%= link_to t('.edit_profile'), edit_profile_path(current_user), class: "mx-auto bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline", data: { turbo: false } %>
+    <%= link_to t('.edit_profile'), edit_profile_path, class: "mx-auto bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline", data: { turbo: false } %>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
     <% end %>
     <nav class="md:ml-20 md:mr-10 flex flex-wrap items-center text-base justify-center">
       <%= link_to t('defaults.top'), root_path, class:"mx-6 hover:text-gray-900", data: { turbo: false } %>
-      <%= link_to t('defaults.profile'), profile_path(current_user), class:"mx-6 hover:text-gray-900", data: { turbo: false } %>
+      <%= link_to t('defaults.profile'), profile_path, class:"mx-6 hover:text-gray-900", data: { turbo: false } %>
       <%= link_to t('defaults.logout'), logout_path, class:"mx-6 hover:text-gray-900", data: { turbo_method: :delete, turbo_confirm: t('user_sessions.destroy.confirm') } %>
     </nav>
   </div>


### PR DESCRIPTION
## 概要

プロフィール機能においてroutes.rbでresourceを使用しルーティングを定義していたが画面上でURLの末尾にidが表示されてしまっていたため修正しました

## 確認方法

1. プロフィール詳細画面でidが表示されていないのを確認して下さい
2. プロフィール編集画面でidが表示されていないのを確認して下さい

## 影響範囲

プロフィール機能

## チェックリスト

- [x] Lint のチェックをパスした

