### PR TITLE
Fix header position

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,10 +1,10 @@
 <header class="text-gray-600 body-font sticky top-0 bg-red-100 bg-opacity-90 z-50">
-  <div class="container mx-auto flex flex-wrap flex-col md:flex-row items-center">
+  <div class="container mx-auto flex flex-wrap flex-col md:flex-row items-center justify-between">
   <%= link_to root_path, class:"flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0" do %>
     <%= image_tag 'logo.webp', class: 'w-30 h-24' %>
     <span class="-ml-7 text-xl">for you.</span>
   <% end %>
-    <nav class="md:ml-20 md:mr-10 flex flex-wrap items-center text-base justify-center">
+    <nav class="md:ml-auto flex flex-wrap items-center text-base">
       <%= link_to t('defaults.login'), login_path , class:"mx-6 hover:text-gray-900", data: { turbo: false } %>
       <%= link_to t('defaults.registration'), step1_users_path, class:"mx-6 hover:text-gray-900", data: { turbo: false } %>
       <a class="mx-6 hover:text-gray-900">ゲストログイン</a>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,10 +1,10 @@
 <header class="text-gray-600 body-font sticky top-0 bg-red-100 bg-opacity-90 z-50">
-  <div class="container mx-auto flex flex-wrap flex-col md:flex-row items-center">
+  <div class="container mx-auto flex flex-wrap flex-col md:flex-row items-center justify-between">
     <%= link_to root_path, class: "flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0" do %>
       <%= image_tag 'logo.webp', class: 'w-30 h-24' %>
       <span class="-ml-7 text-xl">for you.</span>
     <% end %>
-    <nav class="md:ml-20 md:mr-10 flex flex-wrap items-end text-base justify-center">
+    <nav class="md:ml-auto flex flex-wrap items-center text-base">
       <%= link_to t('defaults.top'), root_path, class:"mx-6 hover:text-gray-900", data: { turbo: false } %>
       <%= link_to t('defaults.profile'), profile_path, class:"mx-6 hover:text-gray-900", data: { turbo: false } %>
       <%= link_to t('defaults.logout'), logout_path, class:"mx-6 hover:text-gray-900", data: { turbo_method: :delete, turbo_confirm: t('user_sessions.destroy.confirm') } %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,7 +4,7 @@
       <%= image_tag 'logo.webp', class: 'w-30 h-24' %>
       <span class="-ml-7 text-xl">for you.</span>
     <% end %>
-    <nav class="md:ml-20 md:mr-10 flex flex-wrap items-center text-base justify-center">
+    <nav class="md:ml-20 md:mr-10 flex flex-wrap items-end text-base justify-center">
       <%= link_to t('defaults.top'), root_path, class:"mx-6 hover:text-gray-900", data: { turbo: false } %>
       <%= link_to t('defaults.profile'), profile_path, class:"mx-6 hover:text-gray-900", data: { turbo: false } %>
       <%= link_to t('defaults.logout'), logout_path, class:"mx-6 hover:text-gray-900", data: { turbo_method: :delete, turbo_confirm: t('user_sessions.destroy.confirm') } %>


### PR DESCRIPTION
## 概要

headerのメニュー部分を右寄りになるように訂正しました

## 確認方法

1. ログイン前と後でヘッダーのメニューが右寄り、アイコンが左寄りになっていることを確認してください


## チェックリスト

- [ ] siderをパスした
- [ ] インテグレーションテストを追加した
- [x] Lint のチェックをパスした
- [ ] ユニットテストをパスした
- [ ] 必要なドキュメントを作成した
