### PR TITLE
FIX:line_uid_allow_nil

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ class User < ApplicationRecord
   validates :gender, presence: true
   validates :business, length: { maximum: 20 }
   validates :hobby, length: { maximum: 255 }
-  validates :line_uid, uniqueness: true
+  validates :line_uid, uniqueness: true, allow_nil: true
   enum gender: { man: 0, woman: 1, other: 2 }
   enum role: { general: 0, admin: 1 }
   scope :with_hobby, ->(hobby) { where('hobby @> ARRAY[?]::varchar[]', [hobby]) }


### PR DESCRIPTION
## 概要

ユーザー登録時、またはプロフィール編集時にline_uidのuniqunessでバリデーションにひっかっかる現象があります。
今回line_uidにnilが登録された状態でuniqueが判定されていたので修正しました

## 確認方法

1. ユーザー登録が成功することを確認してください
2. プロフィール編集が成功することを確認してください
3. line連携が成功することを確認してください

## チェックリスト

- [ ] siderをパスした
- [ ] インテグレーションテストを追加した
- [x] Lint のチェックをパスした
- [ ] ユニットテストをパスした
- [ ] 必要なドキュメントを作成した
